### PR TITLE
Support to set options for IUDPSocket.

### DIFF
--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -2834,6 +2834,7 @@ public:
 		(void)ifaddr;
 		(void)mcaddr;
 	}
+	void setOptionBroadcast(bool enable) override { (void)enable; }
 
 	NetworkAddress localAddress() const override { return _localAddress; }
 

--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -2827,6 +2827,13 @@ public:
 		_localAddress = addr;
 		g_sim2.addressMap.emplace(_localAddress, process);
 	}
+	// Ignore those options
+	void setOptionReuseAddress(bool reuse) override { (void)reuse; }
+	void setOptionEnableLoopback(bool enable) override { (void)enable; }
+	void setOptionMulticastGroup(NetworkAddress const& ifaddr, NetworkAddress const& mcaddr) override {
+		(void)ifaddr;
+		(void)mcaddr;
+	}
 
 	NetworkAddress localAddress() const override { return _localAddress; }
 

--- a/flow/Net2.actor.cpp
+++ b/flow/Net2.actor.cpp
@@ -719,6 +719,16 @@ public:
 		}
 	}
 
+	void setOptionBroadcast(bool enable) override {
+		boost::system::error_code ec;
+		socket.set_option(boost::asio::socket_base::broadcast(enable), ec);
+		if (ec) {
+			Error x = invalid_option_value();
+			TraceEvent(SevWarnAlways, "Net2UDPSetOptBroadcastError").error(x);
+			throw x;
+		}
+	}
+
 	void bind(NetworkAddress const& addr) override {
 		boost::system::error_code ec;
 		socket.bind(udpEndpoint(addr), ec);

--- a/flow/Net2.actor.cpp
+++ b/flow/Net2.actor.cpp
@@ -684,6 +684,41 @@ public:
 		return res;
 	}
 
+	void setOptionReuseAddress(bool reuse) override {
+		boost::system::error_code ec;
+		socket.set_option(boost::asio::ip::udp::socket::reuse_address(reuse), ec);
+		if (ec) {
+			Error x = invalid_option_value();
+			TraceEvent(SevWarnAlways, "Net2UDPSetOptReuseAddressError").error(x);
+			throw x;
+		}
+	}
+
+	void setOptionMulticastGroup(NetworkAddress const& ifaddr, NetworkAddress const& mcaddr) override {
+		boost::system::error_code ec;
+		boost::asio::ip::address i;
+		boost::asio::ip::address m;
+		i = boost::asio::ip::address::from_string(ifaddr.ip.toString());
+		m = boost::asio::ip::address::from_string(mcaddr.ip.toString());
+
+		socket.set_option(boost::asio::ip::multicast::join_group(m.to_v4(), i.to_v4()), ec);
+		if (ec) {
+			Error x = invalid_option_value();
+			TraceEvent(SevWarnAlways, "Net2UDPSetOptMulticastGroupError").error(x);
+			throw x;
+		}
+	}
+
+	void setOptionEnableLoopback(bool enable) override {
+		boost::system::error_code ec;
+		socket.set_option(boost::asio::ip::multicast::enable_loopback(enable), ec);
+		if (ec) {
+			Error x = invalid_option_value();
+			TraceEvent(SevWarnAlways, "Net2UDPSetOptEnableLoopbackError").error(x);
+			throw x;
+		}
+	}
+
 	void bind(NetworkAddress const& addr) override {
 		boost::system::error_code ec;
 		socket.bind(udpEndpoint(addr), ec);

--- a/flow/include/flow/IUDPSocket.h
+++ b/flow/include/flow/IUDPSocket.h
@@ -40,6 +40,9 @@ public:
 	virtual Future<int> receive(uint8_t* begin, uint8_t* end) = 0;
 	virtual Future<int> receiveFrom(uint8_t* begin, uint8_t* end, NetworkAddress* sender) = 0;
 	virtual void bind(NetworkAddress const& addr) = 0;
+	virtual void setOptionReuseAddress(bool reuse) = 0;
+	virtual void setOptionMulticastGroup(NetworkAddress const& ifaddr, NetworkAddress const& mcaddr) = 0;
+	virtual void setOptionEnableLoopback(bool reuse) = 0;
 
 	virtual UID getDebugID() const = 0;
 	virtual NetworkAddress localAddress() const = 0;

--- a/flow/include/flow/IUDPSocket.h
+++ b/flow/include/flow/IUDPSocket.h
@@ -42,7 +42,8 @@ public:
 	virtual void bind(NetworkAddress const& addr) = 0;
 	virtual void setOptionReuseAddress(bool reuse) = 0;
 	virtual void setOptionMulticastGroup(NetworkAddress const& ifaddr, NetworkAddress const& mcaddr) = 0;
-	virtual void setOptionEnableLoopback(bool reuse) = 0;
+	virtual void setOptionEnableLoopback(bool enable) = 0;
+	virtual void setOptionBroadcast(bool enable) = 0;
 
 	virtual UID getDebugID() const = 0;
 	virtual NetworkAddress localAddress() const = 0;


### PR DESCRIPTION
Add the following APIs to set options for IUDPSocket.
* setOptionReuseAddress
* setOptionEnableLoopback
* setOptionMulticastGroup
* setOptionBroadcast

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [X] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
